### PR TITLE
Fix 82kB leak of PlayField16 and PlayField8.

### DIFF
--- a/src/game_sp/init.c
+++ b/src/game_sp/init.c
@@ -64,6 +64,12 @@ void sp_open_all(void)
 
 void sp_close_all(void)
 {
+  if (PlayField16)
+    free(PlayField16 - game_sp.preceding_buffer_size);
+  if (PlayField8)
+    free(PlayField8 - SP_MAX_PLAYFIELD_WIDTH);
+  PlayField16 = NULL;
+  PlayField8 = NULL;
 }
 
 void InitPrecedingPlayfieldMemory(void)


### PR DESCRIPTION
This commit fixes an 82 kilobyte leak in the Supaplex engine in Rocks 'n' Diamonds. The `PlayField16` and `PlayField8` variables were initialized in `InitGlobals()` but never freed. 

Subtracting `preceding_buffer_size` and `SP_MAX_PLAYFIELD_WIDTH` from the buffers being freed is necessary because in `InitGlobals` (`src/game_sp/Globals.c` lines 169-179) the pointers to the buffers are moved forward by the corresponding amounts.

Here are the relevant bits from a Valgrind leak-check:
```
==10502==
==10502== 16,608 bytes in 1 blocks are possibly lost in loss record 2,388 of 2,467
==10502==    at 0x4C300A5: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CEA3B: checked_calloc (src/libgame/misc.c:1254)
==10502==    by 0x4FCE45: InitGlobals (src/game_sp/Globals.c:176)
==10502==    by 0x4FE1E2: Form_Load (src/game_sp/MainForm.c:58)
==10502==    by 0x4F7799: sp_open_all (src/game_sp/init.c:62)
==10502==    by 0x40F9C5: OpenAll (src/init.c:6133)
==10502==    by 0x40479E: main (src/main.c:7755)

...
==10502== 
==10502== 67,296 bytes in 1 blocks are possibly lost in loss record 2,414 of 2,467
==10502==    at 0x4C300A5: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CEA3B: checked_calloc (src/libgame/misc.c:1254)
==10502==    by 0x4FCE16: InitGlobals (src/game_sp/Globals.c:170)
==10502==    by 0x4FE1E2: Form_Load (src/game_sp/MainForm.c:58)
==10502==    by 0x4F7799: sp_open_all (src/game_sp/init.c:62)
==10502==    by 0x40F9C5: OpenAll (src/init.c:6133)
==10502==    by 0x40479E: main (src/main.c:7755)
```