### PR TITLE
Fix several leaks in getProgramConfigFilename().

### DIFF
--- a/src/libgame/setup.c
+++ b/src/libgame/setup.c
@@ -501,24 +501,40 @@ char *getProgramConfigFilename(char *command_filename)
 
   char *ro_base_path = getProgramMainDataPath(command_filename, RO_BASE_PATH);
   char *conf_directory = getPath2(ro_base_path, CONF_DIRECTORY);
+  free(ro_base_path);
 
   char *command_basepath = getBasePath(command_filename);
   char *command_basename = getBaseNameNoSuffix(command_filename);
   char *command_filename_2 = getPath2(command_basepath, command_basename);
+  free(command_basepath);
+  free(command_basename);
 
   char *config_filename_1 = getStringCat2(command_filename_1, ".conf");
+  free(command_filename_1);
   char *config_filename_2 = getStringCat2(command_filename_2, ".conf");
+  free(command_filename_2);
   char *config_filename_3 = getPath2(conf_directory, SETUP_FILENAME);
+  free(conf_directory);
 
   // 1st try: look for config file that exactly matches the binary filename
   if (fileExists(config_filename_1))
+  {
+    free(config_filename_2);
+    free(config_filename_3);
     return config_filename_1;
+  }
 
   // 2nd try: look for config file that matches binary filename without suffix
   if (fileExists(config_filename_2))
+  {
+    free(config_filename_1);
+    free(config_filename_3);
     return config_filename_2;
+  }
 
   // 3rd try: return setup config filename in global program config directory
+  free(config_filename_1);
+  free(config_filename_2);
   return config_filename_3;
 }
 


### PR DESCRIPTION
This patch fixes several leaks in `getProgramConfigFilename()` which total to 134 bytes leaked. I've pasted the relevant parts of Valgrind leak report below.
```
==10502== 
==10502== 7 bytes in 1 blocks are definitely lost in loss record 159 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD705: getStringCat2WithSeparator (src/libgame/misc.c:708)
==10502==    by 0x4CD88E: getPath2 (src/libgame/misc.c:750)
==10502==    by 0x4C4826: getProgramConfigFilename (src/libgame/setup.c:503)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 15 bytes in 1 blocks are definitely lost in loss record 375 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD9E9: getStringCopy (src/libgame/misc.c:798)
==10502==    by 0x4CD5D4: getBaseNameNoSuffix (src/libgame/misc.c:664)
==10502==    by 0x4C4846: getProgramConfigFilename (src/libgame/setup.c:506)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 17 bytes in 1 blocks are definitely lost in loss record 414 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD9E9: getStringCopy (src/libgame/misc.c:798)
==10502==    by 0x4C47CD: getProgramConfigFilename (src/libgame/setup.c:496)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 17 bytes in 1 blocks are definitely lost in loss record 415 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD9E9: getStringCopy (src/libgame/misc.c:798)
==10502==    by 0x4CD660: getBasePath (src/libgame/misc.c:681)
==10502==    by 0x4C47AB: getProgramMainDataPath (src/libgame/setup.c:465)
==10502==    by 0x4C4811: getProgramConfigFilename (src/libgame/setup.c:502)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 17 bytes in 1 blocks are definitely lost in loss record 416 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD9E9: getStringCopy (src/libgame/misc.c:798)
==10502==    by 0x4CD660: getBasePath (src/libgame/misc.c:681)
==10502==    by 0x4C4836: getProgramConfigFilename (src/libgame/setup.c:505)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 17 bytes in 1 blocks are definitely lost in loss record 417 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD705: getStringCat2WithSeparator (src/libgame/misc.c:708)
==10502==    by 0x4CD88E: getPath2 (src/libgame/misc.c:750)
==10502==    by 0x4C485D: getProgramConfigFilename (src/libgame/setup.c:507)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 22 bytes in 1 blocks are definitely lost in loss record 514 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD705: getStringCat2WithSeparator (src/libgame/misc.c:708)
==10502==    by 0x4CD835: getStringCat2 (src/libgame/misc.c:732)
==10502==    by 0x4C4872: getProgramConfigFilename (src/libgame/setup.c:509)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)

==10502== 
==10502== 22 bytes in 1 blocks are definitely lost in loss record 515 of 2,467
==10502==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==10502==    by 0x4CE9F6: checked_malloc (src/libgame/misc.c:1242)
==10502==    by 0x4CD705: getStringCat2WithSeparator (src/libgame/misc.c:708)
==10502==    by 0x4CD835: getStringCat2 (src/libgame/misc.c:732)
==10502==    by 0x4C4887: getProgramConfigFilename (src/libgame/setup.c:510)
==10502==    by 0x4045A6: InitProgramConfig (src/main.c:7679)
==10502==    by 0x40475E: main (src/main.c:7747)
```