### PR TITLE
Build-script: use three argument open in create_element_defs.pl

### DIFF
--- a/build-scripts/create_element_defs.pl
+++ b/build-scripts/create_element_defs.pl
@@ -230,7 +230,7 @@ sub print_file_header
 
     $filename_text .= ' ' x (length($filename_tmpl) - length($filename_text));
 
-    open(FILE, "$filename_header_tmpl") ||
+    open(FILE, '<', "$filename_header_tmpl") ||
 	fail("cannot open file '$filename_header_tmpl' for reading");
 
     while (<FILE>)
@@ -282,7 +282,7 @@ sub print_graphics_list
 
     print_file_header($filename_conf_gfx_h, $text_gfx_h);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $max_num_tabs = 7;
@@ -436,7 +436,7 @@ sub print_sounds_list
 
     print_file_header($filename_conf_snd_h, $text_snd_h);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $max_num_tabs = 7;
@@ -501,7 +501,7 @@ sub print_music_list
 
     print_file_header($filename_conf_mus_h, $text_mus_h);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $max_num_tabs = 7;
@@ -895,7 +895,7 @@ sub get_known_element_definitions_ALTERNATIVE
 
     my $filename = "$src_path/main.h";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     while (<FILE>)
@@ -922,7 +922,7 @@ sub get_known_element_definitions
 
     my $filename = "$src_path/main.c";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $element_name = '';
@@ -985,7 +985,7 @@ sub get_known_element_class_definitions
 
     my $filename = "$src_path/main.c";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $element_name = '';
@@ -1066,7 +1066,7 @@ sub get_known_action_definitions
 
     my $filename = "$src_path/main.h";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     while (<FILE>)
@@ -1093,7 +1093,7 @@ sub get_known_special_arg_definitions
 
     my $filename = "$src_path/main.h";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     while (<FILE>)
@@ -1125,7 +1125,7 @@ sub get_known_button_definitions
 
     my $filename = "$src_path/conf_gfx.h";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     while (<FILE>)
@@ -1152,7 +1152,7 @@ sub get_known_font_definitions
 
     my $filename = "$src_path/main.h";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     while (<FILE>)
@@ -1186,7 +1186,7 @@ sub get_known_music_prefix_definitions
 
     my $filename = "$src_path/main.c";
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     my $prefix_name = '';
@@ -1418,7 +1418,7 @@ sub print_element_to_graphic_list
 
     print_file_header($filename_conf_e2g_c, $text_e2g_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -1697,7 +1697,7 @@ sub print_element_to_special_graphic_list
 
     print_file_header($filename_conf_esg_c, $text_esg_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -1872,7 +1872,7 @@ sub print_element_to_sound_list
 
     print_file_header($filename_conf_e2s_c, $text_e2s_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -2051,7 +2051,7 @@ sub print_font_to_graphic_list
 
     print_file_header($filename_conf_fnt_c, $text_fnt_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -2155,7 +2155,7 @@ sub print_gamemode_to_sound_list
 
     print_file_header($filename_conf_g2s_c, $text_g2s_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -2245,7 +2245,7 @@ sub print_gamemode_to_music_list
 
     print_file_header($filename_conf_g2m_c, $text_g2m_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "static struct\n";
@@ -2330,7 +2330,7 @@ sub print_image_config_vars
 
     print_file_header($filename_conf_var_c, $text_var_c);
 
-    open(FILE, "$filename") ||
+    open(FILE, '<', "$filename") ||
 	fail("cannot open file '$filename' for reading");
 
     print "struct TokenIntPtrInfo image_config_vars[] =\n";


### PR DESCRIPTION
Include mode in open() calls to prevent accidentally running a command. If the filename begins or ends with a pipe (`|`) symbol, Perl will pipe to or from a command, which is probably not what we want.

According to [`perldoc -f open`](https://perldoc.perl.org/functions/open.html):

> In the one- and two-argument forms of the call, the mode and filename should be concatenated (in that order), preferably separated by white space. **You can--but shouldn't--omit the mode in these forms when that mode is `<` .** It is safe to use the two-argument form of open if the filename argument is a known literal.

Here's the warnings from [`perlcritic`](http://perlcritic.com/) that prompted this pull request (By the way, the `Bareword file handle` warning is harmless, I think):
```
Bareword file handle opened at line 233, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 233, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 285, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 285, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 439, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 439, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 504, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 504, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 898, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 898, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 925, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 925, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 988, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 988, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1069, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1069, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1096, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1096, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1128, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1128, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1155, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1155, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1189, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1189, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1421, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1421, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1700, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1700, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 1875, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 1875, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 2054, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 2054, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 2158, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 2158, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 2248, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 2248, column 5.  See page 207 of PBP.  (Severity: 5)
Bareword file handle opened at line 2333, column 5.  See pages 202,204 of PBP.  (Severity: 5)
Two-argument "open" used at line 2333, column 5.  See page 207 of PBP.  (Severity: 5)
```
