### PR TITLE
Use "%u" conversion specifier for unsigned int

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -12472,7 +12472,7 @@ boolean MovePlayer(struct PlayerInfo *player, int dx, int dy)
     int original_move_delay_value = player->move_delay_value;
 
 #if DEBUG
-    printf("THIS SHOULD ONLY HAPPEN WITH PRE-1.2 LEVEL TAPES. [%d]\n",
+    printf("THIS SHOULD ONLY HAPPEN WITH PRE-1.2 LEVEL TAPES. [%u]\n",
 	   tape.counter);
 #endif
 

--- a/src/libgame/misc.c
+++ b/src/libgame/misc.c
@@ -300,7 +300,7 @@ char *i_to_a(unsigned int i)
 
   a = checked_malloc(10 + 1);
 
-  sprintf(a, "%d", i);
+  sprintf(a, "%u", i);
 
   return a;
 }

--- a/src/libgame/zip/iowin32.c
+++ b/src/libgame/zip/iowin32.c
@@ -263,7 +263,7 @@ static voidpf ZCALLBACK win32_opendisk64_file_funcW(voidpf opaque, voidpf stream
     {
         if (diskFilename[i] != L'.')
             continue;
-        _snwprintf(&diskFilename[i], (iowin->filenameLength + 10) - i, L".z%02d", number_disk + 1);
+        _snwprintf(&diskFilename[i], (iowin->filenameLength + 10) - i, L".z%02u", number_disk + 1);
         break;
     }
     if (i >= 0)
@@ -288,7 +288,7 @@ static voidpf ZCALLBACK win32_opendisk64_file_funcA(voidpf opaque, voidpf stream
     {
         if (diskFilename[i] != '.')
             continue;
-        _snprintf(&diskFilename[i], iowin->filenameLength - i, ".z%02d", number_disk + 1);
+        _snprintf(&diskFilename[i], iowin->filenameLength - i, ".z%02u", number_disk + 1);
         break;
     }
     if (i >= 0)

--- a/src/netserv.c
+++ b/src/netserv.c
@@ -385,9 +385,9 @@ void dumpNetworkBuffer(struct NetworkBuffer *nb)
 {
   int i;
 
-  printf("::: network buffer maximum size: %d\n", nb->max_size);
-  printf("::: network buffer size:         %d\n", nb->size);
-  printf("::: network buffer position    : %d\n", nb->pos);
+  printf("::: network buffer maximum size: %u\n", nb->max_size);
+  printf("::: network buffer size:         %u\n", nb->size);
+  printf("::: network buffer position    : %u\n", nb->pos);
 
   for (i = 0; i < nb->size; i++)
   {


### PR DESCRIPTION
This fixes some Cppcheck warnings:
```
[src\game.c:12477]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\netserv.c:388]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\netserv.c:389]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\netserv.c:390]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\libgame\misc.c:303]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\libgame\zip\iowin32.c:266]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\libgame\zip\iowin32.c:291]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
```